### PR TITLE
Fixing path to bash on OSX

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,15 +19,16 @@
   "workspaceFolder": "/workspaces/development-environment/bootcamp-resources",
 
   "extensions": [
-    "dbaeumer.vscode-eslint",
-    "esbenp.prettier-vscode",
-    "bierner.markdown-preview-github-styles",
-    "ms-vsliveshare.vsliveshare",
-    "ms-vsliveshare.vsliveshare-pack",
-    "ms-azuretools.vscode-docker",
-    "peakchen90.open-html-in-browser",
-    "coenraads.bracket-pair-colorizer-2"
-  ],
+	"dbaeumer.vscode-eslint",
+	"esbenp.prettier-vscode",
+	"bierner.markdown-preview-github-styles",
+	"ms-vsliveshare.vsliveshare",
+	"ms-vsliveshare.vsliveshare-pack",
+	"ms-azuretools.vscode-docker",
+	"peakchen90.open-html-in-browser",
+	"coenraads.bracket-pair-colorizer-2",
+	"mikestead.dotenv"
+],
 
   "forwardPorts": [3000, 8000],
 

--- a/.user.env
+++ b/.user.env
@@ -31,7 +31,7 @@ WIN_BASH_PATH=
 # ----------
 # Default location: '/usr/local/bin/bash'
 #
-OSX_BASH_PATH='/usr/local/bin/bash'
+OSX_BASH_PATH='/bin/bash'
 #
 # On Linux: 
 # ----------

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,6 @@
 {
     "recommendations": [
-        "ms-vscode-remote.remote-containers"
+        "ms-vscode-remote.remote-containers",
+        "mikestead.dotenv"
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
     // Git Bash
     "terminal.integrated.shell.windows": "C:\\Users\\John Doe\\AppData\\Local\\Programs\\Git\bin\\bash.exe",
-    "terminal.integrated.shell.osx": "/usr/local/bin/bash",
+    "terminal.integrated.shell.osx": "/bin/bash",
     "terminal.integrated.shell.linux": "/bin/bash",
 }

--- a/README.md
+++ b/README.md
@@ -159,9 +159,9 @@ Follow the instructions [here](https://docs.github.com/en/github/authenticating-
    #
    # On OSX: 
    # ----------
-   # Default location: '/usr/local/bin/bash'
+   # Default location: '/bin/bash'
    #
-   OSX_BASH_PATH='/usr/local/bin/bash'
+   OSX_BASH_PATH='/bin/bash'
    #
    # On Linux: 
    # ----------


### PR DESCRIPTION
Updated path to bash for OSX; Added dotenv plugin to workspace and devcontainer extensions